### PR TITLE
modify removeKeyFromObject to return undefined if resulting object is empty per its contract

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -31,7 +31,7 @@ export function removeKeyFromObject(key, obj) {
 		obj = { ...obj };
 		delete obj[key];
 	}
-	return obj;
+	return Object.keys(obj).length ? obj : undefined;
 }
 
 /** An empty function.


### PR DESCRIPTION
fixes travis-ci failures and returns it to its contract